### PR TITLE
Initialize AI stock tool skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # FACAI
+
+Initial codebase for an AI-assisted stock analysis tool targeting A-share
+and Hong Kong markets.
+
+## Features
+
+- Fetches basic market data from Yahoo Finance.
+- Placeholder hooks for policy information and AI text analysis (Doubao or
+  DeepSeek).
+- Simple price-based stock filtering example.
+
+## Usage
+
+```
+python main.py
+```
+
+The script retrieves sample quotes, filters them by price, and prints a
+basic AI-generated summary. Network access is required for live data.

--- a/facai/__init__.py
+++ b/facai/__init__.py
@@ -1,0 +1,3 @@
+"""FACAI package initial code for AI stock trading tool."""
+
+__all__ = ["data_collector", "ai_integration", "stock_selector"]

--- a/facai/ai_integration.py
+++ b/facai/ai_integration.py
@@ -1,0 +1,36 @@
+"""AI integration layer for FACAI.
+
+This module provides a minimal interface to interact with AI services
+such as Volcengine's Doubao or DeepSeek. For demonstration purposes, the
+functions below do not perform real API calls but illustrate the expected
+interface for future expansion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AIClient:
+    """Simple AI client placeholder.
+
+    Attributes:
+        model: Name of the model being used. Supported values include
+            ``"doubao"`` and ``"deepseek"``. The client does not enforce the
+            model choice in this initial version.
+    """
+
+    model: str = "doubao"
+
+    def summarize(self, text: str) -> str:
+        """Return a dummy summary of ``text``.
+
+        A real implementation would call the respective AI model's API to
+        analyze the text. Here, we simply truncate the text to demonstrate
+        the integration point.
+        """
+
+        if len(text) > 200:
+            return text[:200] + "..."
+        return text

--- a/facai/data_collector.py
+++ b/facai/data_collector.py
@@ -1,0 +1,56 @@
+"""Data collection utilities for FACAI.
+
+This module contains minimal functions to fetch market and policy
+information for A shares and Hong Kong stocks. The implementation uses
+Yahoo Finance's public quote API via the standard library so it has no
+third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict
+from urllib.request import urlopen
+from urllib.parse import urlencode
+
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+
+
+def fetch_stock_quote(symbol: str) -> Dict:
+    """Fetch real-time quote for a given stock symbol.
+
+    Args:
+        symbol: Stock symbol compatible with Yahoo Finance. Examples:
+            ``"000001.SS"`` for the SSE Composite Index or ``"0700.HK"`` for
+            Tencent Holdings.
+
+    Returns:
+        A dictionary with quote information. The function returns an empty
+        dictionary if the symbol is not found or a network error occurs.
+    """
+
+    try:
+        url = f"{YAHOO_QUOTE_URL}?{urlencode({'symbols': symbol})}"
+        with urlopen(url, timeout=10) as response:  # nosec B310
+            payload = json.loads(response.read().decode("utf-8"))
+        data = payload.get("quoteResponse", {}).get("result", [])
+        if data:
+            return data[0]
+    except Exception as exc:  # pragma: no cover - network errors
+        logging.warning("Failed to fetch quote for %s: %s", symbol, exc)
+    return {}
+
+
+def fetch_policy_news() -> str:
+    """Placeholder for policy news scraping.
+
+    This function should eventually scrape or query official policy and
+    regulatory news relevant to A shares and Hong Kong markets. For now, it
+    simply returns a static string.
+    """
+
+    return (
+        "No policy news fetching implemented yet. This function acts as a "
+        "placeholder to demonstrate where such logic would live."
+    )

--- a/facai/stock_selector.py
+++ b/facai/stock_selector.py
@@ -1,0 +1,29 @@
+"""Stock selection helpers for FACAI."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def filter_by_price(quotes: Dict[str, Dict], *, min_price: float = 0.0, max_price: float = float("inf")) -> Dict[str, Dict]:
+    """Filter quotes by price range.
+
+    Args:
+        quotes: Mapping of stock symbol to quote dictionaries as returned by
+            :func:`facai.data_collector.fetch_stock_quote`.
+        min_price: Minimum acceptable price.
+        max_price: Maximum acceptable price.
+
+    Returns:
+        A new dictionary containing only the symbols whose current price is
+        within the specified range.
+    """
+
+    filtered = {}
+    for symbol, data in quotes.items():
+        price = data.get("regularMarketPrice")
+        if price is None:
+            continue
+        if min_price <= price <= max_price:
+            filtered[symbol] = data
+    return filtered

--- a/main.py
+++ b/main.py
@@ -1,0 +1,39 @@
+"""Entry point for the FACAI demo application.
+
+This script demonstrates a minimal workflow:
+
+1. Fetch market data for a set of symbols.
+2. Filter the data based on price constraints.
+3. Summarise the results using the AI integration layer.
+
+The script targets Windows execution but is cross-platform and can run on
+any system with Python and network access.
+"""
+
+from __future__ import annotations
+
+from facai.ai_integration import AIClient
+from facai.data_collector import fetch_stock_quote, fetch_policy_news
+from facai.stock_selector import filter_by_price
+
+
+def main() -> None:
+    symbols = ["000001.SS", "0700.HK"]  # SSE Composite Index and Tencent
+    quotes = {sym: fetch_stock_quote(sym) for sym in symbols}
+
+    # Simple selection: keep stocks with price between 1 and 1000
+    selected = filter_by_price(quotes, min_price=1, max_price=1000)
+
+    ai = AIClient(model="doubao")
+
+    print("Policy News:")
+    print(fetch_policy_news())
+    print("\nSelected Stocks:")
+    for sym, data in selected.items():
+        text = f"{sym} current price is {data.get('regularMarketPrice')} {data.get('currency')}"
+        summary = ai.summarize(text)
+        print(f"- {summary}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold FACAI package with modules for data collection, AI integration, and stock selection
- add demo entry script for fetching quotes and summarising with placeholder AI
- document usage in README

## Testing
- `python main.py` *(fails to fetch data due to blocked network but runs without crashing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d47dc6ac8325a36e7190faa4891e