### PR TITLE
chore: wrap long lines to satisfy E501

### DIFF
--- a/app/clients/ark_client.py
+++ b/app/clients/ark_client.py
@@ -19,19 +19,28 @@ class ArkClient:
     real requests when integrating with the actual Ark API.
     """
 
-    def __init__(self, api_base: Optional[str] = None, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
         self.api_base = api_base or settings.ARK_API_BASE
         self.api_key = api_key or settings.ARK_API_KEY
         self.session = requests.Session()
 
-    # Knowledge base management -------------------------------------------------
+    # Knowledge base management
     def create_kb(self, name: str, desc: str = "") -> Dict[str, Any]:
         """Create a knowledge base. Returns mock response."""
         logger.info("Mock create_kb called: %s", name)
         # TODO: implement API call
         return {"kb_id": "mock-kb-id", "name": name, "desc": desc}
 
-    def upsert_document(self, kb_id: str, file: Optional[str] = None, text: str = "") -> Dict[str, Any]:
+    def upsert_document(
+        self,
+        kb_id: str,
+        file: Optional[str] = None,
+        text: str = "",
+    ) -> Dict[str, Any]:
         """Upload or update a document in the KB."""
         logger.info("Mock upsert_document in %s", kb_id)
         # TODO: implement API call with file or text
@@ -43,7 +52,7 @@ class ArkClient:
         # TODO: implement API call
         return {"kb_id": kb_id, "query": query, "results": ["mock result"]}
 
-    # Chat ---------------------------------------------------------------------
+    # Chat
     def chat(
         self,
         messages: Iterable[Dict[str, str]],

--- a/app/data/akshare_fetch.py
+++ b/app/data/akshare_fetch.py
@@ -22,7 +22,12 @@ def fetch_daily(code: str, start: str, end: str) -> pd.DataFrame:
         import akshare as ak  # type: ignore
 
         logger.info("Fetching data from AKShare for %s", code)
-        df = ak.stock_zh_a_hist(symbol=code, period="daily", start_date=start, end_date=end)
+        df = ak.stock_zh_a_hist(
+            symbol=code,
+            period="daily",
+            start_date=start,
+            end_date=end,
+        )
         df.rename(columns={"日期": "date", "收盘": "close"}, inplace=True)
         df["date"] = pd.to_datetime(df["date"])
         return df[["date", "close"]]

--- a/app/pipelines/chat_with_kb.py
+++ b/app/pipelines/chat_with_kb.py
@@ -14,8 +14,16 @@ def chat_with_kb(query: str, kb_id: Optional[str] = None) -> dict:
     retriever = Retriever(client)
     context = None
     if kb_id or settings.ARK_KB_ID:
-        context = retriever.search(kb_id or settings.ARK_KB_ID, query, top_k=3)
-    return client.chat([{"role": "user", "content": query}], model=settings.ARK_DEFAULT_MODEL, kb_context=context)
+        context = retriever.search(
+            kb_id or settings.ARK_KB_ID,
+            query,
+            top_k=3,
+        )
+    return client.chat(
+        [{"role": "user", "content": query}],
+        model=settings.ARK_DEFAULT_MODEL,
+        kb_context=context,
+    )
 
 
 __all__ = ["chat_with_kb"]

--- a/app/pipelines/finetune_job.py
+++ b/app/pipelines/finetune_job.py
@@ -4,7 +4,8 @@
 def schedule_finetune_job():
     """Schedule a fine-tuning job on Ark platform.
 
-    TODO: implement fine-tuning orchestration when API becomes available.
+    TODO: implement fine-tuning orchestration when API becomes
+    available.
     """
     pass
 

--- a/app/pipelines/research_orchestrator.py
+++ b/app/pipelines/research_orchestrator.py
@@ -27,15 +27,25 @@ def run_research(query: str) -> Dict[str, object]:
     code = parse_code(query) or "000001.SZ"
     end = datetime.today()
     start = end - timedelta(days=365 * 3)
-    df = fetch_daily(code, start.strftime("%Y%m%d"), end.strftime("%Y%m%d"))
+    df = fetch_daily(
+        code,
+        start.strftime("%Y%m%d"),
+        end.strftime("%Y%m%d"),
+    )
     df = fill_missing(adjust_prices(df))
 
     factor_metrics, features = run_factor_analysis(df)
     bt_metrics, equity = backtest_strategy(features, label="momentum")
 
     client = ArkClient()
-    prompt = quant_research_template({"code": code}, {**factor_metrics, **bt_metrics})
-    ai_resp = client.chat([{"role": "user", "content": prompt}], model=settings.ARK_DEFAULT_MODEL)
+    prompt = quant_research_template(
+        {"code": code},
+        {**factor_metrics, **bt_metrics},
+    )
+    ai_resp = client.chat(
+        [{"role": "user", "content": prompt}],
+        model=settings.ARK_DEFAULT_MODEL,
+    )
     summary = ai_resp.get("reply", "")
 
     return {

--- a/app/rag/prompt_templates.py
+++ b/app/rag/prompt_templates.py
@@ -3,17 +3,27 @@
 from typing import Dict, Any
 
 
-def quant_research_template(context: Dict[str, Any], metrics: Dict[str, Any]) -> str:
+def quant_research_template(
+    context: Dict[str, Any],
+    metrics: Dict[str, Any],
+) -> str:
     """Build prompt for quantitative research summary."""
     return (
         "Quantitative research results for {code}. Metrics: {metrics}. "
-        "Provide a short performance summary including Sharpe ratio and drawdown."
-    ).format(code=context.get("code", "unknown"), metrics=metrics)
+        "Provide a short performance summary including "
+        "Sharpe ratio and drawdown."
+    ).format(
+        code=context.get("code", "unknown"),
+        metrics=metrics,
+    )
 
 
 def announce_summary_template(context: str, query: str) -> str:
     """Template for summarising announcements or news."""
-    return f"Given the following context: {context}. Answer the query: {query}"
+    return (
+        f"Given the following context: {context}. "
+        f"Answer the query: {query}"
+    )
 
 
 __all__ = ["quant_research_template", "announce_summary_template"]


### PR DESCRIPTION
## Summary
- wrap lengthy signatures in Ark client
- split long calls in data fetching, chat, and research orchestration pipelines
- reformat prompt templates and docstrings to stay within line limits

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b7e02a72208325906298f4afc89423