### PR TITLE
Remove unused imports and guard ArkClient type hints

### DIFF
--- a/app/rag/kb_manager.py
+++ b/app/rag/kb_manager.py
@@ -1,6 +1,11 @@
 """Knowledge base management helpers."""
 
-from app.clients.ark_client import ArkClient
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.clients.ark_client import ArkClient
 
 
 class KBManager:

--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -1,6 +1,11 @@
 """Retriever using ArkClient search API."""
 
-from app.clients.ark_client import ArkClient
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.clients.ark_client import ArkClient
 
 
 class Retriever:

--- a/app/research/qlib_runner.py
+++ b/app/research/qlib_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, Tuple
 
 import pandas as pd
 

--- a/cli/facai.py
+++ b/cli/facai.py
@@ -6,7 +6,6 @@ from app.clients.ark_client import ArkClient
 from app.pipelines.chat_with_kb import chat_with_kb
 from app.pipelines.research_orchestrator import run_research
 from app.rag.kb_manager import KBManager
-from app.settings import settings
 
 app = typer.Typer()
 kb_app = typer.Typer()


### PR DESCRIPTION
## Summary
- drop unused imports in CLI and research modules
- guard ArkClient-only type hints with TYPE_CHECKING blocks

## Testing
- `flake8` *(fails: command not found, installation blocked by proxy)*
- `PYTHONPATH=. pytest` *(fails: PydanticImportError: `BaseSettings` moved to pydantic-settings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e02c1aac83258147c6e53c2bc2ab